### PR TITLE
Add LookInside debug server

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -9,26 +9,27 @@
 /* Begin PBXBuildFile section */
 		50A560892F2E68F800762F0F /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = 50A560882F2E68F800762F0F /* MarkdownView */; };
 		50A560902F2E68F800762F0F /* WatchMarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = 50A560912F2E68F800762F0F /* WatchMarkdownView */; };
+		50F259092F5F143000DE874B /* ExampleWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 50F259082F5F143000DE874B /* ExampleWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		51A1000A2F90000100AAA001 /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = 51A100082F90000100AAA001 /* MarkdownView */; };
 		51A1000B2F90000100AAA001 /* MarkdownParser in Frameworks */ = {isa = PBXBuildFile; productRef = 51A100092F90000100AAA001 /* MarkdownParser */; };
 		51A100142F90000100AAA001 /* Litext in Frameworks */ = {isa = PBXBuildFile; productRef = 51A100152F90000100AAA001 /* Litext */; };
-		50F259092F5F143000DE874B /* ExampleWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 50F259082F5F143000DE874B /* ExampleWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		CEC412AB953519504ACA57EC /* LookInsideServer in Frameworks */ = {isa = PBXBuildFile; productRef = 8155B0F4083D31F6F63E4AC1 /* LookInsideServer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		51A1000C2F90000100AAA001 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 505E99E22D26D8380014A6D3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 50A5607C2F2E687B00762F0F;
-			remoteInfo = Example;
-		};
 		50F2590A2F5F143000DE874B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 505E99E22D26D8380014A6D3 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 50F259072F5F143000DE874B;
 			remoteInfo = "ExampleWatch Watch App";
+		};
+		51A1000C2F90000100AAA001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 505E99E22D26D8380014A6D3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 50A5607C2F2E687B00762F0F;
+			remoteInfo = Example;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -48,25 +49,31 @@
 
 /* Begin PBXFileReference section */
 		50A5607D2F2E687B00762F0F /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		51A100032F90000100AAA001 /* MarkdownViewCatalystTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarkdownViewCatalystTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		50F259032F5F143000DE874B /* ExampleWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		50F259082F5F143000DE874B /* ExampleWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ExampleWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		51A100032F90000100AAA001 /* MarkdownViewCatalystTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarkdownViewCatalystTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		50A5607E2F2E687B00762F0F /* Example */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = Example;
-			sourceTree = "<group>";
-		};
-		51A100042F90000100AAA001 /* MarkdownViewCatalystTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = MarkdownViewCatalystTests;
 			sourceTree = "<group>";
 		};
 		50F2590C2F5F143000DE874B /* ExampleWatch Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = "ExampleWatch Watch App";
+			sourceTree = "<group>";
+		};
+		51A100042F90000100AAA001 /* MarkdownViewCatalystTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			path = MarkdownViewCatalystTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -77,6 +84,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50A560892F2E68F800762F0F /* MarkdownView in Frameworks */,
+				CEC412AB953519504ACA57EC /* LookInsideServer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,9 +159,50 @@
 			name = Example;
 			packageProductDependencies = (
 				50A560882F2E68F800762F0F /* MarkdownView */,
+				8155B0F4083D31F6F63E4AC1 /* LookInsideServer */,
 			);
 			productName = Example;
 			productReference = 50A5607D2F2E687B00762F0F /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		50F259022F5F143000DE874B /* ExampleWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 50F259192F5F143100DE874B /* Build configuration list for PBXNativeTarget "ExampleWatch" */;
+			buildPhases = (
+				50F259012F5F143000DE874B /* Resources */,
+				50F259152F5F143100DE874B /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				50F2590B2F5F143000DE874B /* PBXTargetDependency */,
+			);
+			name = ExampleWatch;
+			productName = ExampleWatch;
+			productReference = 50F259032F5F143000DE874B /* ExampleWatch.app */;
+			productType = "com.apple.product-type.application.watchapp2-container";
+		};
+		50F259072F5F143000DE874B /* ExampleWatch Watch App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 50F259182F5F143100DE874B /* Build configuration list for PBXNativeTarget "ExampleWatch Watch App" */;
+			buildPhases = (
+				50F259042F5F143000DE874B /* Sources */,
+				50F259052F5F143000DE874B /* Frameworks */,
+				50F259062F5F143000DE874B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				50F2590C2F5F143000DE874B /* ExampleWatch Watch App */,
+			);
+			name = "ExampleWatch Watch App";
+			packageProductDependencies = (
+				50A560912F2E68F800762F0F /* WatchMarkdownView */,
+			);
+			productName = "ExampleWatch Watch App";
+			productReference = 50F259082F5F143000DE874B /* ExampleWatch Watch App.app */;
 			productType = "com.apple.product-type.application";
 		};
 		51A100022F90000100AAA001 /* MarkdownViewCatalystTests */ = {
@@ -182,48 +231,6 @@
 			productReference = 51A100032F90000100AAA001 /* MarkdownViewCatalystTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		50F259022F5F143000DE874B /* ExampleWatch */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 50F259192F5F143100DE874B /* Build configuration list for PBXNativeTarget "ExampleWatch" */;
-			buildPhases = (
-				50F259012F5F143000DE874B /* Resources */,
-				50F259152F5F143100DE874B /* Embed Watch Content */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				50F2590B2F5F143000DE874B /* PBXTargetDependency */,
-			);
-			name = ExampleWatch;
-			packageProductDependencies = (
-			);
-			productName = ExampleWatch;
-			productReference = 50F259032F5F143000DE874B /* ExampleWatch.app */;
-			productType = "com.apple.product-type.application.watchapp2-container";
-		};
-		50F259072F5F143000DE874B /* ExampleWatch Watch App */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 50F259182F5F143100DE874B /* Build configuration list for PBXNativeTarget "ExampleWatch Watch App" */;
-			buildPhases = (
-				50F259042F5F143000DE874B /* Sources */,
-				50F259052F5F143000DE874B /* Frameworks */,
-				50F259062F5F143000DE874B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				50F2590C2F5F143000DE874B /* ExampleWatch Watch App */,
-			);
-			name = "ExampleWatch Watch App";
-			packageProductDependencies = (
-				50A560912F2E68F800762F0F /* WatchMarkdownView */,
-			);
-			productName = "ExampleWatch Watch App";
-			productReference = 50F259082F5F143000DE874B /* ExampleWatch Watch App.app */;
-			productType = "com.apple.product-type.application";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -237,15 +244,15 @@
 					50A5607C2F2E687B00762F0F = {
 						CreatedOnToolsVersion = 26.2;
 					};
-					51A100022F90000100AAA001 = {
-						CreatedOnToolsVersion = 26.3;
-						TestTargetID = 50A5607C2F2E687B00762F0F;
-					};
 					50F259022F5F143000DE874B = {
 						CreatedOnToolsVersion = 26.3;
 					};
 					50F259072F5F143000DE874B = {
 						CreatedOnToolsVersion = 26.3;
+					};
+					51A100022F90000100AAA001 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 50A5607C2F2E687B00762F0F;
 					};
 				};
 			};
@@ -259,8 +266,10 @@
 			mainGroup = 505E99E12D26D8380014A6D3;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				0AD8B6BEB2233A9950678FB5 /* XCRemoteSwiftPackageReference "LookInside-Release" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 505E99EB2D26D8380014A6D3 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -328,15 +337,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		51A1000D2F90000100AAA001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 50A5607C2F2E687B00762F0F /* Example */;
-			targetProxy = 51A1000C2F90000100AAA001 /* PBXContainerItemProxy */;
-		};
 		50F2590B2F5F143000DE874B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 50F259072F5F143000DE874B /* ExampleWatch Watch App */;
 			targetProxy = 50F2590A2F5F143000DE874B /* PBXContainerItemProxy */;
+		};
+		51A1000D2F90000100AAA001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 50A5607C2F2E687B00762F0F /* Example */;
+			targetProxy = 51A1000C2F90000100AAA001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -523,6 +532,10 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
+				EXCLUDED_SOURCE_FILE_NAMES = (
+					"$(inherited)",
+					"LookInsideServer*",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -553,58 +566,6 @@
 				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 26.0;
-			};
-			name = Release;
-		};
-		51A100112F90000100AAA001 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 964G86XT2P;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.MarkdownViewCatalystTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				STRING_CATALOG_GENERATE_SYMBOLS = NO;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example";
-			};
-			name = Debug;
-		};
-		51A100122F90000100AAA001 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 964G86XT2P;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.MarkdownViewCatalystTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				STRING_CATALOG_GENERATE_SYMBOLS = NO;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example";
 			};
 			name = Release;
 		};
@@ -708,6 +669,58 @@
 			};
 			name = Release;
 		};
+		51A100112F90000100AAA001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 964G86XT2P;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.MarkdownViewCatalystTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example";
+			};
+			name = Debug;
+		};
+		51A100122F90000100AAA001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 964G86XT2P;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.MarkdownViewCatalystTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Example";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -725,15 +738,6 @@
 			buildConfigurations = (
 				50A560862F2E687C00762F0F /* Debug */,
 				50A560872F2E687C00762F0F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		51A100132F90000100AAA001 /* Build configuration list for PBXNativeTarget "MarkdownViewCatalystTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				51A100112F90000100AAA001 /* Debug */,
-				51A100122F90000100AAA001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -756,12 +760,36 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		51A100132F90000100AAA001 /* Build configuration list for PBXNativeTarget "MarkdownViewCatalystTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				51A100112F90000100AAA001 /* Debug */,
+				51A100122F90000100AAA001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0AD8B6BEB2233A9950678FB5 /* XCRemoteSwiftPackageReference "LookInside-Release" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/LookInsideApp/LookInside-Release.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		50A560882F2E68F800762F0F /* MarkdownView */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MarkdownView;
+		};
+		50A560912F2E68F800762F0F /* WatchMarkdownView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WatchMarkdownView;
 		};
 		51A100082F90000100AAA001 /* MarkdownView */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -775,9 +803,10 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Litext;
 		};
-		50A560912F2E68F800762F0F /* WatchMarkdownView */ = {
+		8155B0F4083D31F6F63E4AC1 /* LookInsideServer */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = WatchMarkdownView;
+			package = 0AD8B6BEB2233A9950678FB5 /* XCRemoteSwiftPackageReference "LookInside-Release" */;
+			productName = LookInsideServer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ This project includes code adapted from [swift-markdown-ui](https://github.com/g
 ---
 
 Copyright 2025 © Lakr Aream. All rights reserved.
+## Sponsor
+
+[LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 This project includes code adapted from [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) by Guillermo Gonzalez, used under the MIT License.
 
----
-
-Copyright 2025 © Lakr Aream. All rights reserved.
 ## Sponsor
 
 [LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.
+
+---
+
+Copyright 2025 © Lakr Aream. All rights reserved.


### PR DESCRIPTION
## What changed

- Add the LookInside-Release Swift package and link the LookInsideServer product into the app target.
- Exclude LookInsideServer from Release builds with `EXCLUDED_SOURCE_FILE_NAMES = $(inherited) LookInsideServer*`.
- Add the LookInside sponsor block to the root README.

## Validation

- Debug build passes.
- Release build passes.
- Debug artifact contains LookInsideServer.
- Release artifact excludes LookInsideServer.
