### PR TITLE
Fix vertical scrolling over macOS code blocks

### DIFF
--- a/Sources/MarkdownView/Components/CodeView/CodeView.swift
+++ b/Sources/MarkdownView/Components/CodeView/CodeView.swift
@@ -243,7 +243,7 @@ import Litext
 
         lazy var barView: NSView = .init()
         lazy var scrollView: NSScrollView = {
-            let sv = NSScrollView()
+            let sv = HorizontalScrollView()
             sv.hasVerticalScroller = false
             sv.hasHorizontalScroller = false
             sv.drawsBackground = false

--- a/Sources/MarkdownView/Components/HorizontalScrollView.swift
+++ b/Sources/MarkdownView/Components/HorizontalScrollView.swift
@@ -1,0 +1,41 @@
+//
+//  HorizontalScrollView.swift
+//  MarkdownView
+//
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    import AppKit
+
+    /// A horizontally scrolling view that forwards vertical wheel gestures to
+    /// its responder chain so an enclosing vertical scroller can handle them.
+    ///
+    /// The gesture axis is locked on its first meaningful delta to avoid
+    /// switching handlers when trackpad events contain movement on both axes.
+    final class HorizontalScrollView: NSScrollView {
+        private var lockedToVertical: Bool?
+
+        override func scrollWheel(with event: NSEvent) {
+            if event.phase.isEmpty, event.momentumPhase.isEmpty {
+                lockedToVertical = nil
+            }
+            if event.phase.contains(.began) {
+                lockedToVertical = nil
+            }
+            if event.momentumPhase.contains(.ended) || event.momentumPhase.contains(.cancelled) {
+                lockedToVertical = nil
+            }
+
+            let deltaX = abs(event.scrollingDeltaX)
+            let deltaY = abs(event.scrollingDeltaY)
+            if lockedToVertical == nil, deltaX > 0 || deltaY > 0 {
+                lockedToVertical = deltaY > deltaX
+            }
+
+            if lockedToVertical == true {
+                nextResponder?.scrollWheel(with: event)
+            } else {
+                super.scrollWheel(with: event)
+            }
+        }
+    }
+#endif

--- a/Sources/MarkdownView/Components/TableView/TableView.swift
+++ b/Sources/MarkdownView/Components/TableView/TableView.swift
@@ -267,50 +267,6 @@ import Litext
 #elseif canImport(AppKit)
     import AppKit
 
-    /// NSScrollView subclass that passes vertical scroll events to the next
-    /// responder, allowing the parent chat list to scroll normally when the
-    /// user scrolls over a table that only needs horizontal scrolling.
-    ///
-    /// Axis is locked at gesture start so mixed-delta trackpad events don't
-    /// stutter between horizontal and vertical handling mid-gesture.
-    private final class TableScrollView: NSScrollView {
-        // nil = undecided; locked once first meaningful delta arrives
-        private var lockedToVertical: Bool?
-
-        override func scrollWheel(with event: NSEvent) {
-            // Legacy mouse-wheel events carry no phases; decide the axis
-            // per event instead of latching it for the gesture.
-            if event.phase.isEmpty, event.momentumPhase.isEmpty {
-                lockedToVertical = nil
-            }
-            // Reset at the start of each new gesture (deltas are 0 at .began,
-            // so don't lock yet — wait for first real movement below).
-            if event.phase.contains(.began) {
-                lockedToVertical = nil
-            }
-            // Release after momentum ends so the next gesture starts fresh.
-            if event.momentumPhase.contains(.ended) || event.momentumPhase.contains(.cancelled) {
-                lockedToVertical = nil
-            }
-
-            // Lock axis on first event that carries real movement.
-            let dx = abs(event.scrollingDeltaX)
-            let dy = abs(event.scrollingDeltaY)
-            if lockedToVertical == nil, dx > 0 || dy > 0 {
-                // Favour horizontal so tables are usable; vertical wins only
-                // when dy is clearly dominant.
-                lockedToVertical = dy > dx
-            }
-
-            let isVertical = lockedToVertical ?? false
-            if isVertical {
-                nextResponder?.scrollWheel(with: event)
-            } else {
-                super.scrollWheel(with: event)
-            }
-        }
-    }
-
     final class TableView: NSView {
         typealias Rows = [NSAttributedString]
 
@@ -322,8 +278,8 @@ import Litext
 
         // MARK: - UI Components
 
-        private lazy var scrollView: TableScrollView = {
-            let sv = TableScrollView()
+        private lazy var scrollView: HorizontalScrollView = {
+            let sv = HorizontalScrollView()
             sv.hasVerticalScroller = false
             sv.hasHorizontalScroller = true
             sv.autohidesScrollers = true

--- a/Tests/MarkdownViewTests/MarkdownViewLayoutTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownViewLayoutTests.swift
@@ -241,6 +241,23 @@ struct MarkdownViewLayoutTests {
         #expect(codeView.interactionTarget(at: CGPoint(x: 240, y: 20)) != nil)
     }
 
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+        @MainActor
+        @Test("Code forwards vertical scroll events to its responder chain")
+        func codeForwardsVerticalScrollEvents() throws {
+            let container = ScrollWheelProbe(frame: .init(x: 0, y: 0, width: 260, height: 160))
+            let codeView = CodeView(frame: container.bounds)
+            codeView.theme = .default
+            codeView.content = "let value = 1"
+            container.addSubview(codeView)
+            layout(view: codeView)
+
+            codeView.scrollView.scrollWheel(with: try makeScrollWheelEvent(deltaY: 1))
+
+            #expect(container.eventCount == 1)
+        }
+    #endif
+
     @MainActor
     @Test("MarkdownTextView height grows as width shrinks")
     func markdownTextViewHeightGrowsAsWidthShrinks() {
@@ -594,6 +611,30 @@ private func extractGridView(from scrollView: TestScrollView) -> GridView? {
         scrollView.documentView as? GridView
     #endif
 }
+
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+    @MainActor
+    private final class ScrollWheelProbe: NSView {
+        private(set) var eventCount = 0
+
+        override func scrollWheel(with _: NSEvent) {
+            eventCount += 1
+        }
+    }
+
+    @MainActor
+    private func makeScrollWheelEvent(deltaY: Int32) throws -> NSEvent {
+        let cgEvent = try #require(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .line,
+            wheelCount: 1,
+            wheel1: deltaY,
+            wheel2: 0,
+            wheel3: 0
+        ))
+        return try #require(NSEvent(cgEvent: cgEvent))
+    }
+#endif
 
 private func language(at needle: String, in attributedString: NSAttributedString) -> String? {
     let range = (attributedString.string as NSString).range(of: needle)


### PR DESCRIPTION
## Summary

- reuse an axis-locked horizontal scroll view for macOS code blocks and tables
- forward vertical wheel gestures through the responder chain so enclosing views continue scrolling
- keep the AppKit-specific event handling out of Mac Catalyst
- add a regression test for vertical scrolling over a code block

## Testing

- `xcodebuild -workspace Example.xcworkspace -scheme Example -destination 'platform=macOS,variant=Mac Catalyst' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build` (with `xcbeautify`)