### PR TITLE
Cut a streaming rebuild by 42%

### DIFF
--- a/Sources/MarkdownView/Components/CodeView/CodeHighlighter.swift
+++ b/Sources/MarkdownView/Components/CodeView/CodeHighlighter.swift
@@ -36,6 +36,13 @@ public final class CodeHighlighter {
 
     static let highlightDidUpdateNotification = Notification.Name("wiki.qaq.MarkdownView.CodeHighlighter.highlightDidUpdate")
 
+    /// The keys whose highlighting finished, as a `Set<Int>` in the user info.
+    ///
+    /// Every view listens to one shared notification, so without this a code
+    /// block finishing in one message rebuilds every other message on screen.
+    /// A notification arriving without it is taken as possibly relevant.
+    static let highlightedKeysUserInfoKey = "wiki.qaq.MarkdownView.CodeHighlighter.highlightedKeys"
+
     private let worker = HighlightWorker()
     private var pendingRequests: OrderedDictionary<Int, CodeHighlightRequest> = [:]
     private var inflightKey: Int?
@@ -263,7 +270,11 @@ extension CodeHighlighter {
         defer { processNextRequestIfNeeded() }
         guard renderCache.value(forKey: key) == nil else { return }
         renderCache.setValue(map, forKey: key)
-        NotificationCenter.default.post(name: Self.highlightDidUpdateNotification, object: nil)
+        NotificationCenter.default.post(
+            name: Self.highlightDidUpdateNotification,
+            object: nil,
+            userInfo: [Self.highlightedKeysUserInfoKey: Set([key])]
+        )
     }
 }
 

--- a/Sources/MarkdownView/Components/TableView/TableView.swift
+++ b/Sources/MarkdownView/Components/TableView/TableView.swift
@@ -265,6 +265,50 @@ private func fittedTableColumnWidths(
             return mutableAttributedString
         }
 
+        /// What produced the cells this view is currently showing.
+        ///
+        /// Rendering a table means turning every cell's inline nodes into an
+        /// attributed string, and a stream asks for that on every token even
+        /// when the table itself has not changed since the last one. Comparing
+        /// the source the cells came from lets the builder skip that work
+        /// instead of doing it and then discovering it was not needed.
+        private struct RenderedSource {
+            let rows: [RawTableRow]
+            let columnAlignments: [RawTableColumnAlignment]
+            let theme: MarkdownTheme
+            let representedText: NSAttributedString
+        }
+
+        private var renderedSource: RenderedSource?
+
+        /// The text standing in for this table, if it already shows `rows`.
+        func representedText(
+            reusingRows rows: [RawTableRow],
+            columnAlignments: [RawTableColumnAlignment],
+            theme: MarkdownTheme
+        ) -> NSAttributedString? {
+            guard let renderedSource,
+                  renderedSource.theme == theme,
+                  renderedSource.columnAlignments == columnAlignments,
+                  renderedSource.rows == rows
+            else { return nil }
+            return renderedSource.representedText
+        }
+
+        func rememberRenderedSource(
+            rows: [RawTableRow],
+            columnAlignments: [RawTableColumnAlignment],
+            theme: MarkdownTheme,
+            representedText: NSAttributedString
+        ) {
+            renderedSource = .init(
+                rows: rows,
+                columnAlignments: columnAlignments,
+                theme: theme,
+                representedText: representedText
+            )
+        }
+
         private func contentsEqual(_ lhs: [Rows], _ rhs: [Rows]) -> Bool {
             guard lhs.count == rhs.count else { return false }
             for rowIndex in lhs.indices {
@@ -563,6 +607,50 @@ private func fittedTableColumnWidths(
                 range: NSRange(location: 0, length: mutableString.length)
             )
             return mutableAttributedString
+        }
+
+        /// What produced the cells this view is currently showing.
+        ///
+        /// Rendering a table means turning every cell's inline nodes into an
+        /// attributed string, and a stream asks for that on every token even
+        /// when the table itself has not changed since the last one. Comparing
+        /// the source the cells came from lets the builder skip that work
+        /// instead of doing it and then discovering it was not needed.
+        private struct RenderedSource {
+            let rows: [RawTableRow]
+            let columnAlignments: [RawTableColumnAlignment]
+            let theme: MarkdownTheme
+            let representedText: NSAttributedString
+        }
+
+        private var renderedSource: RenderedSource?
+
+        /// The text standing in for this table, if it already shows `rows`.
+        func representedText(
+            reusingRows rows: [RawTableRow],
+            columnAlignments: [RawTableColumnAlignment],
+            theme: MarkdownTheme
+        ) -> NSAttributedString? {
+            guard let renderedSource,
+                  renderedSource.theme == theme,
+                  renderedSource.columnAlignments == columnAlignments,
+                  renderedSource.rows == rows
+            else { return nil }
+            return renderedSource.representedText
+        }
+
+        func rememberRenderedSource(
+            rows: [RawTableRow],
+            columnAlignments: [RawTableColumnAlignment],
+            theme: MarkdownTheme,
+            representedText: NSAttributedString
+        ) {
+            renderedSource = .init(
+                rows: rows,
+                columnAlignments: columnAlignments,
+                theme: theme,
+                representedText: representedText
+            )
         }
 
         private func contentsEqual(_ lhs: [Rows], _ rhs: [Rows]) -> Bool {

--- a/Sources/MarkdownView/MarkdownTextBuilder/BlockProcessor.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/BlockProcessor.swift
@@ -154,17 +154,32 @@ final class BlockProcessor {
         rows: [RawTableRow]
     ) -> (NSAttributedString, TableView) {
         let tableView = viewProvider.acquireTableView()
-        let contents = rows.map {
-            $0.cells.map { rawCell in
-                rawCell.content.render(theme: theme, context: context, viewProvider: viewProvider)
+        let representedText: NSAttributedString
+        if let reused = tableView.representedText(
+            reusingRows: rows,
+            columnAlignments: columnAlignments,
+            theme: theme
+        ) {
+            representedText = reused
+        } else {
+            let contents = rows.map {
+                $0.cells.map { rawCell in
+                    rawCell.content.render(theme: theme, context: context, viewProvider: viewProvider)
+                }
             }
+            let allContent = contents
+                .map { $0.map(\.string).joined(separator: "\t") }
+                .joined(separator: "\n")
+            representedText = NSAttributedString(string: allContent + "\n")
+            tableView.setTheme(theme)
+            tableView.setContents(contents, columnAlignments: columnAlignments)
+            tableView.rememberRenderedSource(
+                rows: rows,
+                columnAlignments: columnAlignments,
+                theme: theme,
+                representedText: representedText
+            )
         }
-        let allContent = contents
-            .map { $0.map(\.string).joined(separator: "\t") }
-            .joined(separator: "\n")
-        let representedText = NSAttributedString(string: allContent + "\n")
-        tableView.setTheme(theme)
-        tableView.setContents(contents, columnAlignments: columnAlignments)
 
         let text = buildWithParagraphSync { paragraph in
             paragraph.minimumLineHeight = tableView.intrinsicContentHeight

--- a/Sources/MarkdownView/MarkdownTextBuilder/MarkdownContent.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/MarkdownContent.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import LRUCache
 import MarkdownParser
 
 /// Parsed and pre-rendered markdown, ready for display in ``MarkdownTextView``.
@@ -13,17 +14,35 @@ import MarkdownParser
 /// Build one off the main thread for streaming scenarios, or use
 /// ``init(markdown:theme:locale:)`` for one-shot rendering.
 public final class MarkdownContent: @unchecked Sendable {
-    private struct InlineRenderCacheKey: Hashable {
+    /// What a rendered piece of body text depends on.
+    ///
+    /// The font and colour are held as themselves rather than as a formatted
+    /// description of them. Describing them cost more than every other part of
+    /// rendering the text put together, and it also made two colours that
+    /// happen to resolve alike today share one entry — which hands a caller
+    /// asking for a dynamic colour a copy frozen in the current appearance.
+    /// Fonts and colours are immutable once handed to a theme, so a key holding
+    /// them can cross the actor boundary the cache requires.
+    private struct InlineRenderCacheKey: Hashable, @unchecked Sendable {
         let text: String
         let localeIdentifier: String
-        let themeSignature: String
+        let font: PlatformFont
+        let color: PlatformColor
     }
+
+    /// Rendered body text, shared by every content rather than owned by one.
+    ///
+    /// Streaming builds a fresh ``MarkdownContent`` for each token, so a cache
+    /// living on the instance never saw a second lookup in the one situation it
+    /// exists for. Shared, a stream re-renders only the paragraph that grew.
+    /// Bounded by entry count, and cleared under memory pressure by `LRUCache`.
+    @MainActor private static let inlineRenderCache =
+        LRUCache<InlineRenderCacheKey, NSAttributedString>(countLimit: 4096)
 
     public let blocks: [MarkdownBlockNode]
     public let rendered: RenderedTextContent.Map
     public let highlightMaps: [Int: CodeHighlighter.HighlightMap]
     public let locale: Locale
-    @MainActor private var inlineRenderCache: [InlineRenderCacheKey: NSAttributedString] = [:]
 
     public init(
         blocks: [MarkdownBlockNode],
@@ -75,9 +94,10 @@ public final class MarkdownContent: @unchecked Sendable {
         let key = InlineRenderCacheKey(
             text: text,
             localeIdentifier: locale.identifier,
-            themeSignature: theme.inlineBodyCacheSignature
+            font: theme.fonts.body,
+            color: theme.colors.body
         )
-        if let cached = inlineRenderCache[key] {
+        if let cached = Self.inlineRenderCache.value(forKey: key) {
             return cached
         }
 
@@ -92,8 +112,14 @@ public final class MarkdownContent: @unchecked Sendable {
             to: rendered,
             fallbackLocale: locale
         )
+        // Resolve the fallback font here, once per distinct piece of text,
+        // rather than leaving it to the pass over the finished document.
+        // The body font covers no CJK and no emoji, so that pass was asking
+        // CoreText for a substitute for the same runs on every rebuild — a
+        // third of the cost of a streaming update.
+        rendered.fixAttributes(in: NSRange(location: 0, length: rendered.length))
         let cached = rendered.copy() as! NSAttributedString
-        inlineRenderCache[key] = cached
+        Self.inlineRenderCache.setValue(cached, forKey: key)
         return cached
     }
 }
@@ -101,28 +127,6 @@ public final class MarkdownContent: @unchecked Sendable {
 public extension MarkdownTextView {
     @available(*, deprecated, renamed: "MarkdownContent")
     typealias PreprocessedContent = MarkdownContent
-}
-
-private extension MarkdownTheme {
-    var inlineBodyCacheSignature: String {
-        [
-            fonts.body.fontName,
-            String(format: "%.4f", Double(fonts.body.pointSize)),
-            colors.body.cacheDescription,
-        ].joined(separator: "|")
-    }
-}
-
-private extension PlatformColor {
-    var cacheDescription: String {
-        #if canImport(UIKit)
-            guard let components = cgColor.components else { return description }
-        #elseif canImport(AppKit)
-            guard let converted = usingColorSpace(.deviceRGB) else { return description }
-            guard let components = converted.cgColor.components else { return description }
-        #endif
-        return components.map { String(format: "%.4f", $0) }.joined(separator: ",")
-    }
 }
 
 public extension MarkdownParser.ParseResult {

--- a/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder.swift
@@ -63,9 +63,13 @@ final class TextBuilder {
     struct BuildResult {
         let document: NSAttributedString
         let subviews: [PlatformView]
+        /// Highlight cache keys of every code block in this document, so a view
+        /// can tell whether a finished highlight is one of its own.
+        let highlightKeys: Set<Int>
     }
 
     private var pendingHighlightRequests: [CodeHighlightRequest] = []
+    private var highlightKeys: Set<Int> = []
 
     private var previouslyBuilt = false
     func build() -> BuildResult {
@@ -79,7 +83,7 @@ final class TextBuilder {
         if !pendingHighlightRequests.isEmpty {
             CodeHighlighter.current.scheduleHighlight(requests: pendingHighlightRequests)
         }
-        return .init(document: text, subviews: subviewCollector)
+        return .init(document: text, subviews: subviewCollector, highlightKeys: highlightKeys)
     }
 }
 
@@ -122,6 +126,7 @@ extension TextBuilder {
             return blockProcessor.processThematicBreak()
         case let .codeBlock(language, content):
             let highlightKey = CodeHighlighter.current.key(for: content, language: language)
+            highlightKeys.insert(highlightKey)
             var highlightMap = context.highlightMaps[highlightKey]
             if highlightMap == nil {
                 highlightMap = CodeHighlighter.current.cachedHighlightMap(for: highlightKey)

--- a/Sources/MarkdownView/MarkdownTextView/MarkdownTextView+Private.swift
+++ b/Sources/MarkdownView/MarkdownTextView/MarkdownTextView+Private.swift
@@ -16,8 +16,18 @@ extension MarkdownTextView {
 
         NotificationCenter.default
             .publisher(for: CodeHighlighter.highlightDidUpdateNotification)
-            .sink { [weak self] _ in
+            .sink { [weak self] notification in
                 guard let self else { return }
+                // One shared notification reaches every view on screen, so a
+                // code block finishing in one message used to rebuild all of
+                // them. A notification that does not name the blocks it
+                // finished still means a rebuild — it could be any of them.
+                if let keys = notification.userInfo?[CodeHighlighter.highlightedKeysUserInfoKey]
+                    as? Set<Int>,
+                    renderedHighlightKeys.isDisjoint(with: keys)
+                {
+                    return
+                }
                 use(content)
             }
             .store(in: &cancellables)

--- a/Sources/MarkdownView/MarkdownTextView/MarkdownTextView+Update.swift
+++ b/Sources/MarkdownView/MarkdownTextView/MarkdownTextView+Update.swift
@@ -35,6 +35,7 @@ import Litext
             let artifacts = TextBuilder.build(view: self, viewProvider: viewProvider)
             textLabelView.attributedText = artifacts.document
             contextViews = artifacts.subviews
+            renderedHighlightKeys = artifacts.highlightKeys
 
             for view in artifacts.subviews {
                 if let view = view as? CodeView {
@@ -84,6 +85,7 @@ import Litext
             let artifacts = TextBuilder.build(view: self, viewProvider: viewProvider)
             textLabelView.attributedText = artifacts.document
             contextViews = artifacts.subviews
+            renderedHighlightKeys = artifacts.highlightKeys
 
             for view in artifacts.subviews {
                 if let view = view as? CodeView {

--- a/Sources/MarkdownView/MarkdownTextView/MarkdownTextView.swift
+++ b/Sources/MarkdownView/MarkdownTextView/MarkdownTextView.swift
@@ -36,6 +36,8 @@ import MarkdownParser
 
         var contextViews: [UIView] = []
         var blockquoteBars: [BlockquoteBarView] = []
+        /// Highlight cache keys of the code blocks this view is showing.
+        var renderedHighlightKeys: Set<Int> = []
         var cancellables = Set<AnyCancellable>()
         let contentSubject = CurrentValueSubject<MarkdownContent, Never>(.init())
         public var throttleInterval: TimeInterval? = 1 / 20 { // x fps
@@ -157,6 +159,8 @@ import MarkdownParser
 
         var contextViews: [NSView] = []
         var blockquoteBars: [BlockquoteBarView] = []
+        /// Highlight cache keys of the code blocks this view is showing.
+        var renderedHighlightKeys: Set<Int> = []
         var cancellables = Set<AnyCancellable>()
         let contentSubject = CurrentValueSubject<MarkdownContent, Never>(.init())
         public var throttleInterval: TimeInterval? = 1 / 20 { // x fps

--- a/Tests/MarkdownViewTests/MarkdownCodeHighlightRebuildTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownCodeHighlightRebuildTests.swift
@@ -132,6 +132,53 @@ struct MarkdownCodeHighlightRebuildTests {
     }
 
     @MainActor
+    @Test("A finished highlight only reaches the views showing that block")
+    func onlyTheViewsShowingTheBlockPickUpAHighlight() {
+        // Built before the cache is warm, so the code starts out unhighlighted
+        // and picking up colour is proof that a rebuild happened.
+        let source = "let uniqueToThisTest = 1"
+        let document = markdown(source)
+        let view = RenderProbe.view(document)
+        guard let unhighlighted = codeView(in: view) else {
+            Issue.record("no code view was built")
+            return
+        }
+        #expect(distinctColors(in: unhighlighted).count == 1)
+
+        warmHighlightCache(for: document)
+        let strangerKey = CodeHighlighter.current.key(
+            for: "print(\"a block this view never showed\")",
+            language: "python"
+        )
+        postHighlightUpdate(keys: [strangerKey])
+        RenderProbe.layout(view)
+
+        #expect(distinctColors(in: unhighlighted).count == 1, "an unrelated block rebuilt this view")
+
+        let ownKeys = Set(MarkdownParser().parse(document).document.compactMap { block -> Int? in
+            guard case let .codeBlock(language, content) = block else { return nil }
+            return CodeHighlighter.current.key(for: content, language: language)
+        })
+        postHighlightUpdate(keys: ownKeys)
+        RenderProbe.layout(view)
+
+        guard let rebuiltCodeView = codeView(in: view) else {
+            Issue.record("the code view went away")
+            return
+        }
+        #expect(distinctColors(in: rebuiltCodeView).count > 1)
+    }
+
+    @MainActor
+    private func postHighlightUpdate(keys: Set<Int>) {
+        NotificationCenter.default.post(
+            name: CodeHighlighter.highlightDidUpdateNotification,
+            object: nil,
+            userInfo: [CodeHighlighter.highlightedKeysUserInfoKey: keys]
+        )
+    }
+
+    @MainActor
     @Test("Code text reaches the view verbatim")
     func codeTextReachesTheViewVerbatim() {
         let view = RenderProbe.view(markdown(Self.source))

--- a/Tests/MarkdownViewTests/MarkdownInlineCacheTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownInlineCacheTests.swift
@@ -218,6 +218,102 @@ struct MarkdownInlineCacheTests {
     }
 
     @MainActor
+    @Test("Two contents share one rendering of the same text")
+    func renderedTextIsSharedBetweenContents() {
+        // Streaming builds a new content per token, so a cache that does not
+        // reach across instances never gets a second lookup. Asserting the
+        // shared instance is what keeps that from quietly reverting.
+        let first = RenderProbe.content("placeholder")
+        let second = RenderProbe.content("placeholder")
+        let theme = MarkdownTheme.default
+
+        let fromFirst = first.cachedBodyText("共享的一段文字 shared run", theme: theme)
+        let fromSecond = second.cachedBodyText("共享的一段文字 shared run", theme: theme)
+
+        #expect(fromFirst === fromSecond)
+    }
+
+    @MainActor
+    @Test("A shared entry still belongs to its own theme")
+    func sharedCacheKeepsThemesApart() {
+        let first = RenderProbe.content("placeholder")
+        let second = RenderProbe.content("placeholder")
+
+        let small = first.cachedBodyText("同一段文字 same text", theme: themeWithBodyFont(size: 12))
+        let large = second.cachedBodyText("同一段文字 same text", theme: themeWithBodyFont(size: 24))
+
+        #expect((small.attribute(.font, at: 0, effectiveRange: nil) as? PlatformFont)?.pointSize == 12)
+        #expect((large.attribute(.font, at: 0, effectiveRange: nil) as? PlatformFont)?.pointSize == 24)
+    }
+
+    @MainActor
+    @Test("Bold Han text is bold, not merely a fallback font")
+    func boldHanTextKeepsItsWeight() {
+        // Bold is applied by walking the rendered runs and replacing any font
+        // that is still the body font. A cached fragment that already carries a
+        // resolved fallback font is no longer equal to the body font, so this
+        // asserts the outcome — bold Han differs from plain Han — rather than
+        // the branch that produces it.
+        let view = RenderProbe.view("普通中文 and **加粗中文** together.")
+        let text = view.textLabelView.attributedText
+
+        let plain = RenderProbe.font(at: "普通中文", in: text)
+        let bold = RenderProbe.font(at: "加粗中文", in: text)
+
+        #expect(plain != nil)
+        #expect(bold != nil)
+        #expect(bold != plain)
+    }
+
+    @MainActor
+    @Test("Two colors that resolve alike are still cached apart")
+    func colorsThatResolveAlikeAreCachedApart() {
+        // A dynamic color repaints itself when the appearance changes; a literal
+        // one with the same components today does not. A cache that keys on the
+        // resolved components hands the dynamic caller the frozen color and the
+        // text stops following dark mode.
+        let dynamic = MarkdownTheme.default.colors.body
+        let literal = frozenCopy(of: dynamic)
+        let content = RenderProbe.content("placeholder")
+
+        var dynamicTheme = MarkdownTheme.default
+        dynamicTheme.colors.body = dynamic
+        var literalTheme = MarkdownTheme.default
+        literalTheme.colors.body = literal
+
+        let fromDynamic = content.cachedBodyText("同一段文字", theme: dynamicTheme)
+        let fromLiteral = content.cachedBodyText("同一段文字", theme: literalTheme)
+
+        #expect(
+            fromDynamic.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? PlatformColor === dynamic
+        )
+        #expect(
+            fromLiteral.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? PlatformColor === literal
+        )
+    }
+
+    /// A static color with the same components `color` resolves to right now.
+    @MainActor
+    private func frozenCopy(of color: PlatformColor) -> PlatformColor {
+        #if canImport(UIKit)
+            var red: CGFloat = 0
+            var green: CGFloat = 0
+            var blue: CGFloat = 0
+            var alpha: CGFloat = 0
+            color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+            return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+        #elseif canImport(AppKit)
+            guard let resolved = color.usingColorSpace(.deviceRGB) else { return .black }
+            return NSColor(
+                deviceRed: resolved.redComponent,
+                green: resolved.greenComponent,
+                blue: resolved.blueComponent,
+                alpha: resolved.alphaComponent
+            )
+        #endif
+    }
+
+    @MainActor
     @Test("A repeated word renders the same way at every occurrence")
     func repeatedWordsRenderConsistently() {
         // The obvious way to make the cache cheaper is to key it more loosely.


### PR DESCRIPTION
Every token of a streamed answer rebuilds the whole document. On a 16-section document that was a 11.1 ms median update and a 18.9 ms p90 — the p90 is a dropped frame at 60 Hz, and it grows with the answer. This makes the same update cost 6.4 ms.

Three changes, each measured on its own before the next.

## Where the time was going

Profiled with `os_signpost` intervals at the pipeline seams plus a Time Profiler trace, over 484 streaming updates:

| phase | share of an update |
| --- | --- |
| framesetting (Litext) | 34.6% |
| `fixAttributes` — font fallback | 28.9% |
| node walk | 18.4% |
| tables | 6.8% |
| **parsing** | **4.2%** |

Parsing was never the problem. Three cost centres stood out in the trace: `inlineBodyCacheSignature` at 13.7% of main-thread time (building a cache key), `CTFontCreateForCharactersWithLanguage` at 24.3% (resolving fallback fonts already resolved on the previous update), and `CTFramesetterCreateWithAttributedString` at 23.8%.

## What changed

**The body text cache** — the key was a string spliced from the font name, a formatted point size and the colour's components, rebuilt for every text node to produce a value constant for the whole build. It now holds the font and colour themselves. The cache also lived on the instance, and streaming builds a fresh `MarkdownContent` per token, so in the one workload it exists for it never saw a second lookup; it is now shared and bounded. And the fallback font is resolved there, once per distinct piece of text, instead of on every rebuild of the finished document.

**Tables** — `setContents` rendered every cell, then compared, then returned early. The comparison was right; it came after the work it was meant to avoid. The view now remembers what its cells were rendered from and the builder asks first.

**Highlight notifications** — every view rebuilt whenever any code block anywhere finished highlighting. In a chat list, one code block in one message rebuilt every message on screen. The notification now names the keys that finished.

## Measured

Same-session A/B — the change stashed, rebuilt, and measured back to back on one machine. An earlier cross-session comparison understated every result by about five points and invented two regressions that were not there.

| case | before | after | |
| --- | --- | --- | --- |
| `stream/16` | 11.115 ms | 6.445 ms | −42.0% |
| `stream/16` p90 | 18.9 ms | 11.0 ms | −41.8% |
| `stream/64` | 40.123 ms | 21.714 ms | −45.9% |
| `stream/tail_16` | 20.185 ms | 12.203 ms | −39.5% |
| `build/64` | 66.516 ms | 34.857 ms | −47.6% |
| `first/16` | 37.484 ms | 29.318 ms | −21.8% |
| unchanged 80-row table | 3.190 ms | 0.049 ms | −98.5% |
| re-showing unchanged prose | 3.813 ms | 1.469 ms | −61.5% |
| colour-only theme change | 6.380 ms | 4.138 ms | −35.1% |
| `measure/repeat_width` | 0.000 ms | 0.000 ms | still free |

No case regressed. The `parse/*` cases move ±5% between runs and are untouched code.

## Correctness

109 tests pass (5 added), Mac Catalyst builds. The tests were written before the code moved, because two behaviours were about to be walked past:

- **Bold Han text.** Resolving the fallback font at cache time means a Han run no longer carries the body font, which is exactly what the bold pass tests for. Pinned by asserting bold Han differs from plain Han.
- **Dynamic colours.** The old key described a colour by what it resolved to, so a dynamic colour and a matching literal shared an entry and whichever rendered first was handed to the other, frozen in that appearance. That test failed before this change and passes after.

Also pinned: two contents share one rendering of the same text (a regression here silently undoes the streaming win); a shared entry still belongs to its own theme; a finished highlight only reaches views showing that block.

## Not in this PR

**Framesetting is now 53% of what remains** and is untouched. It lives in Litext, where `TextLabel.Layout.init(attributedString:)` always builds a fresh `CTFramesetter` for the whole document, so appending one character re-typesets every line above it. That is a redesign, not a fix.

**The appearance-change rebuild** on macOS looks unnecessary — colours are stored as dynamic objects and resolve at draw time — but nothing in the suite can prove a dark-mode repaint still lands, and a wrong call there is a visual bug no test would catch. Left alone.

The benchmark harness and the signpost instrumentation used to produce these numbers are deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)