### PR TITLE
Drop the language attribute once it has chosen the font

### DIFF
--- a/Sources/MarkdownView/MarkdownTextBuilder/MarkdownContent.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/MarkdownContent.swift
@@ -118,6 +118,17 @@ public final class MarkdownContent: @unchecked Sendable {
         // CoreText for a substitute for the same runs on every rebuild — a
         // third of the cost of a streaming update.
         rendered.fixAttributes(in: NSRange(location: 0, length: rendered.length))
+        // With the font resolved, the language attribute has done its job for
+        // most scripts — and carrying it into the document triples the cost of
+        // building a framesetter, which is paid again on every rebuild. It stays
+        // only where it still changes what the reader sees.
+        let fullRange = NSRange(location: 0, length: rendered.length)
+        rendered.enumerateAttribute(.coreTextLanguage, in: fullRange, options: []) { value, range, _ in
+            guard let language = value as? String,
+                  !MarkdownContentLocale.affectsShaping(language)
+            else { return }
+            rendered.removeAttribute(.coreTextLanguage, range: range)
+        }
         let cached = rendered.copy() as! NSAttributedString
         Self.inlineRenderCache.setValue(cached, forKey: key)
         return cached

--- a/Sources/MarkdownView/Supplements/MarkdownContentLocale.swift
+++ b/Sources/MarkdownView/Supplements/MarkdownContentLocale.swift
@@ -42,6 +42,26 @@ enum MarkdownContentLocale {
         }
     }
 
+    /// Whether a language still has work to do once the font is resolved.
+    ///
+    /// The attribute exists so CoreText picks the right font and the right
+    /// glyphs for a run. Resolving the font is done once, where the text is
+    /// cached; leaving the attribute in place makes building a framesetter
+    /// three times more expensive, on every rebuild.
+    ///
+    /// Two languages genuinely need it at shaping time, measured over 3166
+    /// ideographs and four widths:
+    ///
+    /// - Traditional Chinese picks a different glyph for 41% of them.
+    /// - Korean breaks lines differently.
+    ///
+    /// Simplified Chinese and Japanese change neither. Anything else — Arabic,
+    /// Hebrew, a language added later — keeps the attribute, because the cost
+    /// of being wrong is a reader seeing the wrong shapes.
+    static func affectsShaping(_ language: String) -> Bool {
+        language != "zh-Hans" && language != "ja"
+    }
+
     static func dominantLanguageIdentifier(
         for text: String,
         fallbackLocale: Locale

--- a/Tests/MarkdownViewTests/MarkdownInlineCacheTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownInlineCacheTests.swift
@@ -85,21 +85,62 @@ struct MarkdownInlineCacheTests {
         #expect(content.cachedBodyText("", theme: theme).string.isEmpty)
     }
 
+    /// The glyphs CoreText would actually draw for `text`.
+    ///
+    /// The locale reaches the reader as a shape, not as an attribute — the same
+    /// codepoint is drawn differently in Simplified and Traditional Chinese —
+    /// so that is what these assert. Whether the shape comes from a resolved
+    /// font or from a language attribute left in place is not the point.
     @MainActor
-    @Test("Han text takes its language from the content locale", arguments: [
-        ("zh-Hans", "zh-Hans"),
-        ("zh-Hant", "zh-Hant"),
-        ("ja", "ja"),
-        ("ko", "ko"),
-        ("en_US", "zh-Hans"),
-    ])
-    func hanTextFollowsTheLocale(localeIdentifier: String, expected: String) {
-        let content = RenderProbe.content("placeholder", locale: .init(identifier: localeIdentifier))
-        let rendered = content.cachedBodyText("汉字", theme: .default)
+    private func glyphs(of text: NSAttributedString) -> [CGGlyph] {
+        let line = CTLineCreateWithAttributedString(text)
+        var result: [CGGlyph] = []
+        for run in (CTLineGetGlyphRuns(line) as NSArray) {
+            let run = run as! CTRun
+            let count = CTRunGetGlyphCount(run)
+            var glyphs = [CGGlyph](repeating: 0, count: count)
+            CTRunGetGlyphs(run, CFRange(location: 0, length: count), &glyphs)
+            result.append(contentsOf: glyphs)
+        }
+        return result
+    }
 
-        #expect(
-            rendered.attribute(.coreTextLanguage, at: 0, effectiveRange: nil) as? String == expected
-        )
+    /// Characters whose shape differs between Simplified and Traditional.
+    private static let variantHan = "直骨門今雪類"
+
+    @MainActor
+    @Test("Han text is drawn the way its locale draws it")
+    func hanTextFollowsTheLocale() {
+        func drawn(_ localeIdentifier: String) -> [CGGlyph] {
+            let content = RenderProbe.content("placeholder", locale: .init(identifier: localeIdentifier))
+            return glyphs(of: content.cachedBodyText(Self.variantHan, theme: .default))
+        }
+
+        let simplified = drawn("zh-Hans")
+        #expect(!simplified.isEmpty)
+        #expect(drawn("zh-Hant") != simplified, "Traditional must not be drawn as Simplified")
+        #expect(drawn("ja") != simplified, "Japanese must not be drawn as Simplified")
+        #expect(drawn("en_US") == simplified, "an unknown locale falls back to Simplified")
+    }
+
+    @MainActor
+    @Test("Only the languages that still change the result keep their attribute")
+    func shapingLanguagesKeepTheirAttribute() {
+        // The attribute triples the cost of building a framesetter, and it is
+        // paid on every rebuild, so it is dropped once the font it selected has
+        // been resolved. It stays for the two languages where dropping it was
+        // measured to change what the reader sees: Traditional Chinese draws
+        // 41% of ideographs differently, and Korean breaks lines differently.
+        func language(_ localeIdentifier: String, _ text: String) -> String? {
+            let content = RenderProbe.content("placeholder", locale: .init(identifier: localeIdentifier))
+            return content.cachedBodyText(text, theme: .default)
+                .attribute(.coreTextLanguage, at: 0, effectiveRange: nil) as? String
+        }
+
+        #expect(language("zh-Hant", "汉字") == "zh-Hant")
+        #expect(language("ko", "한글") == "ko")
+        #expect(language("zh-Hans", "汉字") == nil)
+        #expect(language("ja", "かな") == nil)
     }
 
     @MainActor
@@ -111,8 +152,10 @@ struct MarkdownInlineCacheTests {
         let fromJapanese = japanese.cachedBodyText("汉字", theme: .default)
         let fromChinese = chinese.cachedBodyText("汉字", theme: .default)
 
-        #expect(fromJapanese.attribute(.coreTextLanguage, at: 0, effectiveRange: nil) as? String == "ja")
-        #expect(fromChinese.attribute(.coreTextLanguage, at: 0, effectiveRange: nil) as? String == "zh-Hans")
+        // Two contents, two locales, one shared cache: the entries must not be
+        // the same one, and the difference has to survive as far as the glyphs.
+        #expect(fromJapanese !== fromChinese)
+        #expect(glyphs(of: fromJapanese) != glyphs(of: fromChinese))
     }
 
     @MainActor
@@ -123,11 +166,13 @@ struct MarkdownInlineCacheTests {
         let content = RenderProbe.content("placeholder", locale: .init(identifier: "en_US"))
         let rendered = content.cachedBodyText("かな 한글 العربية עברית plain", theme: .default)
 
-        #expect(RenderProbe.language(at: "か", in: rendered) == "ja")
+        // Korean, Arabic and Hebrew still shape differently with the attribute,
+        // so they keep it. Kana resolves to a Japanese font instead.
         #expect(RenderProbe.language(at: "한", in: rendered) == "ko")
         #expect(RenderProbe.language(at: "ع", in: rendered) == "ar")
         #expect(RenderProbe.language(at: "ע", in: rendered) == "he")
         #expect(RenderProbe.language(at: "plain", in: rendered) == nil)
+        #expect(RenderProbe.font(at: "か", in: rendered) != RenderProbe.font(at: "plain", in: rendered))
     }
 
     @MainActor
@@ -138,8 +183,7 @@ struct MarkdownInlineCacheTests {
         let content = RenderProbe.content("placeholder", locale: .init(identifier: "zh-Hans"))
         let rendered = content.cachedBodyText("日本語かな 中文", theme: .default)
 
-        #expect(RenderProbe.language(at: "日", in: rendered) == "ja")
-        #expect(RenderProbe.language(at: "中", in: rendered) == "zh-Hans")
+        #expect(RenderProbe.font(at: "日", in: rendered) != RenderProbe.font(at: "中", in: rendered))
     }
 
     @MainActor

--- a/Tests/MarkdownViewTests/MarkdownViewLayoutTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownViewLayoutTests.swift
@@ -520,9 +520,10 @@ struct MarkdownViewLayoutTests {
             .text("中文段落 日本語かな العربية")
             .render(theme: .default, context: context, viewProvider: .init())
 
-        #expect(language(at: "中", in: rendered) == "zh-Hans")
-        #expect(language(at: "日", in: rendered) == "ja")
-        #expect(language(at: "か", in: rendered) == "ja")
+        // Simplified Chinese and Japanese carry their locale in the resolved
+        // font rather than in the attribute; Arabic still shapes by language.
+        #expect(font(at: "中", in: rendered) != font(at: "日", in: rendered))
+        #expect(font(at: "日", in: rendered) == font(at: "か", in: rendered))
         #expect(language(at: "ع", in: rendered) == "ar")
     }
 
@@ -801,4 +802,10 @@ private func language(at needle: String, in attributedString: NSAttributedString
     let range = (attributedString.string as NSString).range(of: needle)
     guard range.location != NSNotFound else { return nil }
     return attributedString.attribute(.coreTextLanguage, at: range.location, effectiveRange: nil) as? String
+}
+
+private func font(at needle: String, in attributedString: NSAttributedString) -> PlatformFont? {
+    let range = (attributedString.string as NSString).range(of: needle)
+    guard range.location != NSNotFound else { return nil }
+    return attributedString.attribute(.font, at: range.location, effectiveRange: nil) as? PlatformFont
 }


### PR DESCRIPTION
Follow-on to #18 and #19. Typesetting is the largest remaining phase of a streaming rebuild, and most of it turned out to be one attribute.

## What was measured

Building a `CTFramesetter` for a document MarkdownView produced:

| | runs | framesetter creation |
| --- | --- | --- |
| as built | 579 | 4.399 ms |
| without `.coreTextLanguage` | 515 | **1.279 ms** |
| one font, no other attributes | 1 | 1.546 ms |

Run count barely moves, and stripping every other attribute is *slower* than stripping just this one — so it is the language attribute itself, not fragmentation. That cost is paid on every rebuild, which for a streamed answer means every token.

## Why it can go

The attribute exists so CoreText picks the right font and the right glyphs. The font is already resolved once, where the text is cached, by the `fixAttributes` pass from #18. Whether the attribute still changes anything after that was measured, not assumed — over 3166 ideographs and four widths:

| locale | glyphs | line breaks |
| --- | --- | --- |
| zh-Hans | unchanged | unchanged |
| ja | unchanged | unchanged |
| zh-Hant | **40.8% differ** | — |
| ko | unchanged | **differ at 5 of 16 widths** |

Dropped for Simplified Chinese and Japanese. Kept for Traditional Chinese and Korean because they were measured to need it, and kept for everything else (Arabic, Hebrew, anything added later) because the cost of being wrong is a reader seeing the wrong shapes.

Korean is the reason this is narrower than it first looked: the glyph survey alone said `ko` was safe. Only the line-breaking check caught it.

## Measured

Same-session A/B, median of three runs with cooldowns between them. Parse timings act as a control — untouched code, moved −0.7%.

| case | before | after | |
| --- | --- | --- | --- |
| `shape/inline_heavy` | 11.058 ms | 8.873 ms | −19.8% |
| `stream/append` | 6.080 ms | 5.705 ms | −6.2% |
| `first/64` | 105.096 ms | 99.278 ms | −5.5% |
| `first/16` | 28.968 ms | 27.556 ms | −4.9% |
| `stream/16` | 5.422 ms | 5.160 ms | −4.8% |
| `stream/64` | 17.746 ms | 16.964 ms | −4.4% |
| `measure/repeat_width` | 0.000 ms | 0.000 ms | still free |

Nothing regressed beyond its noise band. Mixed-script documents gain the most, which is what the mechanism predicts.

## Tests

113 pass (1 added), Mac Catalyst builds. The tests that asserted the attribute now assert what the reader sees — that Traditional is not drawn as Simplified, that two locales produce different glyphs, that an unknown locale falls back to Simplified. That is what they were written to protect; the attribute was only ever the mechanism. A new test pins which languages keep it and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)