### PR TITLE
Resolve fallback fonts only where the document changed

### DIFF
--- a/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder.swift
@@ -86,13 +86,35 @@ final class TextBuilder {
         var subviewCollector = [PlatformView]()
         var nextFragmentCache = BlockFragmentCache(theme: theme, content: context)
         let reusesFragments = fragmentCache.isUsable(with: theme, for: context)
+        var fragments = [NSAttributedString]()
+        fragments.reserveCapacity(nodes.count)
+        // Where each newly built block landed, so its fonts can be resolved
+        // after the fact and the resolved copy kept for the next build.
+        var builtRanges = [(slot: Int, range: NSRange)]()
+
         for (index, node) in nodes.enumerated() {
-            let fragment = (reusesFragments ? fragmentCache.fragment(at: index, matching: node) : nil)
-                ?? processBlock(node, context: context, subviews: &subviewCollector)
-            text.append(fragment)
-            nextFragmentCache.record(fragment, for: node)
+            if reusesFragments, let cached = fragmentCache.fragment(at: index, matching: node) {
+                text.append(cached)
+                fragments.append(cached)
+                continue
+            }
+            let start = text.length
+            let built = processBlock(node, context: context, subviews: &subviewCollector)
+            text.append(built)
+            builtRanges.append((fragments.count, NSRange(location: start, length: built.length)))
+            fragments.append(built)
         }
-        text.fixAttributes(in: .init(location: 0, length: text.length))
+
+        for run in Self.coalesced(builtRanges.map(\.range)) {
+            text.fixAttributes(in: run)
+        }
+        for (slot, range) in builtRanges {
+            fragments[slot] = text.attributedSubstring(from: range)
+        }
+
+        for (index, node) in nodes.enumerated() {
+            nextFragmentCache.record(fragments[index], for: node)
+        }
         if !pendingHighlightRequests.isEmpty {
             CodeHighlighter.current.scheduleHighlight(requests: pendingHighlightRequests)
         }
@@ -108,6 +130,27 @@ final class TextBuilder {
 // MARK: - Block Processing
 
 extension TextBuilder {
+    /// Neighbouring ranges merged into one, so a stretch of freshly built
+    /// blocks is resolved in a single pass rather than one pass per block.
+    ///
+    /// A first render builds every block, and merging turns that back into the
+    /// one sweep it has always been; a streamed update builds only the tail,
+    /// and pays for the tail alone.
+    private static func coalesced(_ ranges: [NSRange]) -> [NSRange] {
+        var merged = [NSRange]()
+        for range in ranges where range.length > 0 {
+            if let last = merged.last, last.upperBound == range.location {
+                merged[merged.count - 1] = NSRange(
+                    location: last.location,
+                    length: last.length + range.length
+                )
+            } else {
+                merged.append(range)
+            }
+        }
+        return merged
+    }
+
     private func processBlock(
         _ node: MarkdownBlockNode,
         context: MarkdownContent,

--- a/Tests/MarkdownViewTests/MarkdownFontResolutionTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownFontResolutionTests.swift
@@ -1,0 +1,110 @@
+@testable import MarkdownView
+import Testing
+
+#if canImport(UIKit)
+    import UIKit
+#elseif canImport(AppKit)
+    import AppKit
+#endif
+
+/// The builder resolves fallback fonts one block at a time and caches the
+/// result, rather than sweeping the finished document.
+///
+/// That trade is only sound because `fixAttributes` works a paragraph at a
+/// time and every block ends with a newline, so a block never shares a
+/// paragraph with its neighbour. These pin both halves: that the shortcut
+/// reaches the same attributes as the sweep it replaced, and that the property
+/// it depends on still holds.
+struct MarkdownFontResolutionTests {
+    /// Every block fragment ends with a newline.
+    ///
+    /// This is what keeps paragraph boundaries from crossing a fragment. If a
+    /// block ever stops ending with one, fixing fragments separately stops
+    /// matching fixing the document, and the failure would otherwise show up
+    /// as a subtly wrong paragraph style somewhere far away.
+    @MainActor
+    @Test("Every block ends with a newline")
+    func blocksEndWithNewline() {
+        let view = RenderProbe.view(RenderProbeDocument.everything)
+        let cache = view.blockFragmentCache
+        var checked = 0
+        for (index, node) in view.content.blocks.enumerated() {
+            guard let fragment = cache.fragment(at: index, matching: node) else { continue }
+            checked += 1
+            #expect(
+                fragment.string.hasSuffix("\n"),
+                "block \(index) ends with \(fragment.string.suffix(8).debugDescription)"
+            )
+        }
+        #expect(checked > 0)
+    }
+
+    /// Fixing each block reaches the same document as fixing the whole thing.
+    ///
+    /// Compared through the digest rather than `isEqual`, so a failure names
+    /// the attribute and the offset instead of saying two long strings differ.
+    @MainActor
+    @Test("Per-block font resolution matches a whole-document sweep")
+    func matchesWholeDocumentSweep() {
+        let built = RenderProbe.show(RenderProbeDocument.everything, in: MarkdownTextView())
+
+        let swept = built.mutableCopy() as! NSMutableAttributedString
+        swept.fixAttributes(in: NSRange(location: 0, length: swept.length))
+
+        let before = RenderProbe.digest(built)
+        let after = RenderProbe.digest(swept)
+        #expect(before == after, "\(RenderProbe.firstDifference(before, after))")
+    }
+
+    /// The same, for a document whose scripts the body font does not cover.
+    ///
+    /// CJK and emoji are the runs that actually need a substitute, so they are
+    /// where a missed resolution would show — as a fallback chosen by CoreText
+    /// during framesetting instead of one recorded in the document.
+    @MainActor
+    @Test("Scripts needing a substitute font resolve to a real font", arguments: [
+        "中文段落 with English mixed in.",
+        "日本語の段落です。",
+        "한국어 문단입니다.",
+        "emoji 🎉 in a paragraph 🚀",
+        "# 标题里的中文 heading",
+        "> 引用里的中文 quote",
+        "- 列表里的中文 bullet",
+    ])
+    func substituteFontsAreResolved(_ markdown: String) {
+        let text = RenderProbe.show(markdown, in: MarkdownTextView())
+        let swept = text.mutableCopy() as! NSMutableAttributedString
+        swept.fixAttributes(in: NSRange(location: 0, length: swept.length))
+
+        #expect(
+            RenderProbe.digest(text) == RenderProbe.digest(swept),
+            "\(RenderProbe.firstDifference(RenderProbe.digest(text), RenderProbe.digest(swept)))"
+        )
+    }
+
+    /// A block served from the cache carries its resolved fonts with it.
+    ///
+    /// The whole point of resolving per block is that a streamed update pays
+    /// only for what changed. If a reused fragment came back unresolved, the
+    /// document would still render correctly — CoreText would resolve it again
+    /// while framesetting — and the cost this removes would silently return.
+    @MainActor
+    @Test("A reused block keeps its resolved fonts")
+    func reusedBlocksKeepResolvedFonts() {
+        let markdown = """
+        中文第一段 stays put.
+
+        中文第二段 also stays.
+        """
+        let view = RenderProbe.view(markdown)
+        RenderProbe.show(markdown + "\n\n新的一段 arrives.", in: view)
+
+        let text = view.textLabelView.attributedText
+        let swept = text.mutableCopy() as! NSMutableAttributedString
+        swept.fixAttributes(in: NSRange(location: 0, length: swept.length))
+        #expect(
+            RenderProbe.digest(text) == RenderProbe.digest(swept),
+            "\(RenderProbe.firstDifference(RenderProbe.digest(text), RenderProbe.digest(swept)))"
+        )
+    }
+}


### PR DESCRIPTION
Rendering a body run already resolves its fallback fonts and caches the result, but the builder then swept the whole assembled document again on every rebuild — **12.4% of a streaming update**, spent re-resolving text that had not changed.

## The sweep is not redundant, it is misplaced

Dropping it outright moves the same cost into CoreText, which resolves the fonts again while building a framesetter. Measured on `stream/16`:

| | with the sweep | without |
|---|---|---|
| `fixAttributes` | 229.0 ms | 10.5 ms |
| `typeset` | 1175.6 ms | **1448.0 ms** |
| mean | 5.094 ms | **5.356 ms** |

Net loss. So it moves rather than goes.

## What it does now

`fixAttributes` works a paragraph at a time and every block ends with a newline, so a block never shares a paragraph with its neighbour and can be resolved on its own. Blocks are assembled first, resolved over just the ranges that were newly built, and the resolved text is sliced back into the fragment cache.

Adjacent ranges merge, so a first render — where every block is new — is still the single sweep it always was, while a streamed update pays for the tail alone.

Resolving each block separately instead was tried first: same win while streaming, but a first render regressed up to 16% on short documents, since a few hundred small calls cost more than one large one.

## Measurements

Same-session A/B, `parse/*` as the control at −4.2% to −0.05%:

| case | before | after | |
|---|---|---|---|
| `stream/4` | 1.402 | 1.161 | **−17.2%** |
| `stream/16` | 5.041 | 4.327 | **−14.2%** |
| `stream/table` | 0.449 | 0.382 | −15.0% |
| `build/64` | 25.909 | 22.497 | −13.2% |
| `stream/throttled_16` | 5.512 | 4.986 | −9.6% |
| `stream/append` | 5.404 | 4.950 | −8.4% |
| `first/16` | 26.653 | 26.865 | +0.8% |
| `first/64` | 96.618 | 95.336 | −1.3% |

`stream/64` reads +7.6% on the mean from one 278 ms outlier, against 25–29 ms maxima in the surrounding runs; its p50 moved −10.9%. `stream/code` is +2.6% (0.02 ms) because code blocks are never cached and now take a slice as well.

Cumulative across this line of work: `stream/16` 11.1 ms → 4.33 ms.

## Tests

`MarkdownFontResolutionTests` pins what the shortcut rests on:

- every block ends with a newline — the sole reason per-block resolution matches a whole-document sweep, so a block that stops doing this fails loudly instead of producing a subtly wrong paragraph style elsewhere
- resolving per block reaches the same attributes as sweeping the document, compared attribute by attribute
- the scripts that actually need a substitute font resolve to a real one (Simplified Chinese, Japanese, Korean, emoji, and the same inside a heading, a quote and a list)
- a reused block comes back with its fonts still resolved, so the cost this removes cannot silently return

117 tests pass; Mac Catalyst builds.