### PR TITLE
Let a subclass decorate the body text it renders

### DIFF
--- a/Sources/MarkdownView/Components/TableView/TableView.swift
+++ b/Sources/MarkdownView/Components/TableView/TableView.swift
@@ -309,6 +309,14 @@ private func fittedTableColumnWidths(
             )
         }
 
+        /// Drops the reuse record, so the next build renders the cells again
+        /// even though the rows and the theme are the ones it already drew.
+        /// What the cells rendered *to* can change without either of them
+        /// moving — an inline decoration reading state this table cannot see.
+        func forgetRenderedSource() {
+            renderedSource = nil
+        }
+
         private func contentsEqual(_ lhs: [Rows], _ rhs: [Rows]) -> Bool {
             guard lhs.count == rhs.count else { return false }
             for rowIndex in lhs.indices {
@@ -651,6 +659,14 @@ private func fittedTableColumnWidths(
                 theme: theme,
                 representedText: representedText
             )
+        }
+
+        /// Drops the reuse record, so the next build renders the cells again
+        /// even though the rows and the theme are the ones it already drew.
+        /// What the cells rendered *to* can change without either of them
+        /// moving — an inline decoration reading state this table cannot see.
+        func forgetRenderedSource() {
+            renderedSource = nil
         }
 
         private func contentsEqual(_ lhs: [Rows], _ rhs: [Rows]) -> Bool {

--- a/Sources/MarkdownView/MarkdownTextBuilder/BlockProcessor.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/BlockProcessor.swift
@@ -20,17 +20,20 @@ final class BlockProcessor {
     private let viewProvider: ReusableViewProvider
     private let context: MarkdownContent
     private let thematicBreakDrawing: TextBuilder.DrawingCallback?
+    private let inlineTextDecoration: TextBuilder.InlineTextDecoration?
 
     init(
         theme: MarkdownTheme,
         viewProvider: ReusableViewProvider,
         context: MarkdownContent,
-        thematicBreakDrawing: TextBuilder.DrawingCallback?
+        thematicBreakDrawing: TextBuilder.DrawingCallback?,
+        inlineTextDecoration: TextBuilder.InlineTextDecoration?
     ) {
         self.theme = theme
         self.viewProvider = viewProvider
         self.context = context
         self.thematicBreakDrawing = thematicBreakDrawing
+        self.inlineTextDecoration = inlineTextDecoration
     }
 
     func processHeading(level _: Int, contents: [MarkdownInlineNode]) -> NSAttributedString {
@@ -40,7 +43,7 @@ final class BlockProcessor {
             paragraph.paragraphSpacing = theme.spacings.paragraph
             paragraph.paragraphSpacingBefore = theme.spacings.headingBefore
         } content: {
-            let string = contents.render(theme: theme, context: context, viewProvider: viewProvider)
+            let string = contents.render(theme: theme, context: context, viewProvider: viewProvider, decoration: inlineTextDecoration)
             string.addAttributes(
                 [.font: font],
                 range: NSRange(location: 0, length: string.length)
@@ -54,7 +57,7 @@ final class BlockProcessor {
             paragraph.paragraphSpacing = theme.spacings.paragraph
             paragraph.lineSpacing = 4
         } content: {
-            let rendered = contents.render(theme: theme, context: context, viewProvider: viewProvider)
+            let rendered = contents.render(theme: theme, context: context, viewProvider: viewProvider, decoration: inlineTextDecoration)
             if rendered.length == 0 {
                 return NSMutableAttributedString(string: " ", attributes: [.font: theme.fonts.body])
             }
@@ -117,7 +120,7 @@ final class BlockProcessor {
                 assertionFailure("Blockquote should only contain paragraphs after flattening")
                 continue
             }
-            let paragraphContent = content.render(theme: theme, context: context, viewProvider: viewProvider)
+            let paragraphContent = content.render(theme: theme, context: context, viewProvider: viewProvider, decoration: inlineTextDecoration)
             result.append(paragraphContent)
             if !result.string.hasSuffix("\n") {
                 result.append(NSAttributedString(string: "\n", attributes: [.font: theme.fonts.body]))
@@ -164,7 +167,7 @@ final class BlockProcessor {
         } else {
             let contents = rows.map {
                 $0.cells.map { rawCell in
-                    rawCell.content.render(theme: theme, context: context, viewProvider: viewProvider)
+                    rawCell.content.render(theme: theme, context: context, viewProvider: viewProvider, decoration: inlineTextDecoration)
                 }
             }
             let allContent = contents

--- a/Sources/MarkdownView/MarkdownTextBuilder/ListProcessor.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/ListProcessor.swift
@@ -22,6 +22,7 @@ final class ListProcessor {
     private let bulletDrawing: TextBuilder.BulletDrawingCallback?
     private let numberedDrawing: TextBuilder.NumberedDrawingCallback?
     private let checkboxDrawing: TextBuilder.CheckboxDrawingCallback?
+    private let inlineTextDecoration: TextBuilder.InlineTextDecoration?
 
     init(
         theme: MarkdownTheme,
@@ -29,7 +30,8 @@ final class ListProcessor {
         context: MarkdownContent,
         bulletDrawing: TextBuilder.BulletDrawingCallback?,
         numberedDrawing: TextBuilder.NumberedDrawingCallback?,
-        checkboxDrawing: TextBuilder.CheckboxDrawingCallback?
+        checkboxDrawing: TextBuilder.CheckboxDrawingCallback?,
+        inlineTextDecoration: TextBuilder.InlineTextDecoration?
     ) {
         self.theme = theme
         self.viewProvider = viewProvider
@@ -37,6 +39,7 @@ final class ListProcessor {
         self.bulletDrawing = bulletDrawing
         self.numberedDrawing = numberedDrawing
         self.checkboxDrawing = checkboxDrawing
+        self.inlineTextDecoration = inlineTextDecoration
     }
 
     func processBulletedList(items: [RawListItem]) -> NSAttributedString {
@@ -88,7 +91,7 @@ final class ListProcessor {
                 }),
             ]))
         }
-        string.append(item.paragraph.render(theme: theme, context: context, viewProvider: viewProvider))
+        string.append(item.paragraph.render(theme: theme, context: context, viewProvider: viewProvider, decoration: inlineTextDecoration))
 
         string.addAttributes(
             [.paragraphStyle: paragraphStyle],

--- a/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder+Do.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder+Do.swift
@@ -92,6 +92,10 @@ extension TextBuilder {
         return TextBuilder(nodes: context.blocks, context: context, viewProvider: viewProvider)
             .withTheme(theme)
             .withFragmentCache(view.blockFragmentCache)
+            .withInlineTextDecoration { [weak view] text in
+                guard let view else { return text }
+                return view.decorate(inlineText: text, theme: theme)
+            }
             .withBulletDrawing { context, line, lineOrigin, depth in
                 let style = markerStyle(of: line)
                 let column = ListMarkerLayout.column(lineOrigin: lineOrigin, font: style.font)

--- a/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder+Types.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder+Types.swift
@@ -18,6 +18,10 @@ extension TextBuilder {
     typealias BulletDrawingCallback = (CGContext, CTLine, CGPoint, Int) -> Void
     typealias CheckboxDrawingCallback = (CGContext, CTLine, CGPoint, Bool) -> Void
     typealias NumberedDrawingCallback = (CGContext, CTLine, CGPoint, Int) -> Void
+    /// One run of rendered body text, as the view wants it shown —
+    /// ``MarkdownTextView/decorate(inlineText:theme:)`` seen from the builder.
+    /// The theme is not a parameter because a build has exactly one.
+    typealias InlineTextDecoration = (NSAttributedString) -> NSAttributedString
 }
 
 // MARK: - RenderText

--- a/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder.swift
+++ b/Sources/MarkdownView/MarkdownTextBuilder/TextBuilder.swift
@@ -24,6 +24,7 @@ final class TextBuilder {
     private var numberedDrawing: NumberedDrawingCallback?
     private var checkboxDrawing: CheckboxDrawingCallback?
     private var thematicBreakDrawing: DrawingCallback?
+    private var inlineTextDecoration: InlineTextDecoration?
 
     init(
         nodes: [MarkdownBlockNode],
@@ -57,6 +58,11 @@ final class TextBuilder {
 
     func withThematicBreakDrawing(_ drawing: @escaping DrawingCallback) -> TextBuilder {
         thematicBreakDrawing = drawing
+        return self
+    }
+
+    func withInlineTextDecoration(_ decoration: @escaping InlineTextDecoration) -> TextBuilder {
+        inlineTextDecoration = decoration
         return self
     }
 
@@ -161,6 +167,7 @@ extension TextBuilder {
             viewProvider: viewProvider,
             context: context,
             thematicBreakDrawing: thematicBreakDrawing,
+            inlineTextDecoration: inlineTextDecoration,
         )
 
         let listProcessor = ListProcessor(
@@ -169,7 +176,8 @@ extension TextBuilder {
             context: context,
             bulletDrawing: bulletDrawing,
             numberedDrawing: numberedDrawing,
-            checkboxDrawing: checkboxDrawing
+            checkboxDrawing: checkboxDrawing,
+            inlineTextDecoration: inlineTextDecoration
         )
 
         switch node {

--- a/Sources/MarkdownView/MarkdownTextView/MarkdownTextView.swift
+++ b/Sources/MarkdownView/MarkdownTextView/MarkdownTextView.swift
@@ -11,7 +11,7 @@ import MarkdownParser
 #if canImport(UIKit)
     import UIKit
 
-    public final class MarkdownTextView: UIView {
+    open class MarkdownTextView: UIView {
         public var linkHandler: ((LinkPayload, NSRange, CGPoint) -> Void)?
         public var codePreviewHandler: ((String?, NSAttributedString) -> Void)?
 
@@ -69,7 +69,7 @@ import MarkdownParser
             fatalError("init(coder:) has not been implemented")
         }
 
-        override public func layoutSubviews() {
+        override open func layoutSubviews() {
             super.layoutSubviews()
             textLabelView.frame = bounds
             textLabelView.preferredMaxLayoutWidth = bounds.width
@@ -77,17 +77,56 @@ import MarkdownParser
             syncContextViewLayout()
         }
 
-        override public var intrinsicContentSize: CGSize {
+        override open var intrinsicContentSize: CGSize {
             textLabelView.intrinsicContentSize
         }
 
-        public func boundingSize(for width: CGFloat) -> CGSize {
+        open func boundingSize(for width: CGFloat) -> CGSize {
             textLabelView.preferredMaxLayoutWidth = width
             return textLabelView.intrinsicContentSize
         }
 
+        /// Decorates one run of rendered body text on its way into the document
+        /// — the seam a subclass reaches for to turn plain words into something
+        /// richer, an `@mention` chip being the case this exists for.
+        ///
+        /// Offered for every text run, including those nested inside emphasis,
+        /// strong or a link, and never for inline code, math, HTML, or an
+        /// image's source: each of those is its own inline node, so a pattern
+        /// that appears inside a code span is not mistaken for prose. What the
+        /// enclosing node does afterwards still applies — `strong` sweeps its
+        /// whole range for fonts, `link` for colour — so a decoration inside
+        /// one is styled by it.
+        ///
+        /// The default returns `text` unchanged. An override may return a
+        /// string of a different length, and may carry a Litext attachment: the
+        /// result deliberately sits outside the shared inline render cache, so
+        /// an attachment view built here belongs to this view alone rather than
+        /// to every view that happens to draw the same words. What is handed
+        /// *in*, on the other hand, comes straight from that cache and is read
+        /// by every other view showing the same words — copy it before
+        /// mutating.
+        ///
+        /// Decorated runs do live in this view's fragment cache across
+        /// rebuilds. Call ``invalidateInlineDecoration()`` when whatever an
+        /// override reads from has changed.
+        open func decorate(inlineText text: NSAttributedString, theme _: MarkdownTheme) -> NSAttributedString {
+            text
+        }
+
+        /// Rebuilds the document, dropping text decorated against state that
+        /// has since moved on.
+        public func invalidateInlineDecoration() {
+            assert(Thread.isMainThread)
+            blockFragmentCache = .init()
+            for case let tableView as TableView in contextViews {
+                tableView.forgetRenderedSource()
+            }
+            use(content)
+        }
+
         /// Replaces the displayed content immediately, bypassing the update throttle.
-        public func setContentImmediately(_ content: MarkdownContent) {
+        open func setContentImmediately(_ content: MarkdownContent) {
             assert(Thread.isMainThread)
             resetCombine()
             contentSubject.send(content)
@@ -97,7 +136,7 @@ import MarkdownParser
 
         /// Replaces the displayed content, coalesced by ``throttleInterval``.
         /// Safe to call at high frequency (e.g. while streaming).
-        public func setContent(_ content: MarkdownContent) {
+        open func setContent(_ content: MarkdownContent) {
             contentSubject.send(content)
         }
 
@@ -118,7 +157,7 @@ import MarkdownParser
             setContent(content)
         }
 
-        public func reset() {
+        open func reset() {
             assert(Thread.isMainThread)
             resetCombine()
             contentSubject.send(.init())
@@ -135,7 +174,7 @@ import MarkdownParser
 #elseif canImport(AppKit)
     import AppKit
 
-    public final class MarkdownTextView: NSView {
+    open class MarkdownTextView: NSView {
         public var linkHandler: ((LinkPayload, NSRange, CGPoint) -> Void)?
         public var codePreviewHandler: ((String?, NSAttributedString) -> Void)?
 
@@ -194,16 +233,16 @@ import MarkdownParser
             fatalError("init(coder:) has not been implemented")
         }
 
-        override public var isFlipped: Bool {
+        override open var isFlipped: Bool {
             true
         }
 
-        override public func viewDidChangeEffectiveAppearance() {
+        override open func viewDidChangeEffectiveAppearance() {
             super.viewDidChangeEffectiveAppearance()
             use(content)
         }
 
-        override public func layout() {
+        override open func layout() {
             super.layout()
             textLabelView.frame = bounds
             textLabelView.preferredMaxLayoutWidth = bounds.width
@@ -211,17 +250,56 @@ import MarkdownParser
             syncContextViewLayout()
         }
 
-        override public var intrinsicContentSize: CGSize {
+        override open var intrinsicContentSize: CGSize {
             textLabelView.intrinsicContentSize
         }
 
-        public func boundingSize(for width: CGFloat) -> CGSize {
+        open func boundingSize(for width: CGFloat) -> CGSize {
             textLabelView.preferredMaxLayoutWidth = width
             return textLabelView.intrinsicContentSize
         }
 
+        /// Decorates one run of rendered body text on its way into the document
+        /// — the seam a subclass reaches for to turn plain words into something
+        /// richer, an `@mention` chip being the case this exists for.
+        ///
+        /// Offered for every text run, including those nested inside emphasis,
+        /// strong or a link, and never for inline code, math, HTML, or an
+        /// image's source: each of those is its own inline node, so a pattern
+        /// that appears inside a code span is not mistaken for prose. What the
+        /// enclosing node does afterwards still applies — `strong` sweeps its
+        /// whole range for fonts, `link` for colour — so a decoration inside
+        /// one is styled by it.
+        ///
+        /// The default returns `text` unchanged. An override may return a
+        /// string of a different length, and may carry a Litext attachment: the
+        /// result deliberately sits outside the shared inline render cache, so
+        /// an attachment view built here belongs to this view alone rather than
+        /// to every view that happens to draw the same words. What is handed
+        /// *in*, on the other hand, comes straight from that cache and is read
+        /// by every other view showing the same words — copy it before
+        /// mutating.
+        ///
+        /// Decorated runs do live in this view's fragment cache across
+        /// rebuilds. Call ``invalidateInlineDecoration()`` when whatever an
+        /// override reads from has changed.
+        open func decorate(inlineText text: NSAttributedString, theme _: MarkdownTheme) -> NSAttributedString {
+            text
+        }
+
+        /// Rebuilds the document, dropping text decorated against state that
+        /// has since moved on.
+        public func invalidateInlineDecoration() {
+            assert(Thread.isMainThread)
+            blockFragmentCache = .init()
+            for case let tableView as TableView in contextViews {
+                tableView.forgetRenderedSource()
+            }
+            use(content)
+        }
+
         /// Replaces the displayed content immediately, bypassing the update throttle.
-        public func setContentImmediately(_ content: MarkdownContent) {
+        open func setContentImmediately(_ content: MarkdownContent) {
             assert(Thread.isMainThread)
             resetCombine()
             contentSubject.send(content)
@@ -231,7 +309,7 @@ import MarkdownParser
 
         /// Replaces the displayed content, coalesced by ``throttleInterval``.
         /// Safe to call at high frequency (e.g. while streaming).
-        public func setContent(_ content: MarkdownContent) {
+        open func setContent(_ content: MarkdownContent) {
             contentSubject.send(content)
         }
 
@@ -252,7 +330,7 @@ import MarkdownParser
             setContent(content)
         }
 
-        public func reset() {
+        open func reset() {
             assert(Thread.isMainThread)
             resetCombine()
             contentSubject.send(.init())

--- a/Sources/MarkdownView/Supplements/InlineNode+Render.swift
+++ b/Sources/MarkdownView/Supplements/InlineNode+Render.swift
@@ -17,10 +17,20 @@ import SwiftMath
 
 extension [MarkdownInlineNode] {
     @MainActor
-    func render(theme: MarkdownTheme, context: MarkdownContent, viewProvider: ReusableViewProvider) -> NSMutableAttributedString {
+    func render(
+        theme: MarkdownTheme,
+        context: MarkdownContent,
+        viewProvider: ReusableViewProvider,
+        decoration: TextBuilder.InlineTextDecoration? = nil
+    ) -> NSMutableAttributedString {
         let result = NSMutableAttributedString()
         for node in self {
-            result.append(node.render(theme: theme, context: context, viewProvider: viewProvider))
+            result.append(node.render(
+                theme: theme,
+                context: context,
+                viewProvider: viewProvider,
+                decoration: decoration
+            ))
         }
         return result
     }
@@ -28,11 +38,21 @@ extension [MarkdownInlineNode] {
 
 extension MarkdownInlineNode {
     @MainActor
-    func render(theme: MarkdownTheme, context: MarkdownContent, viewProvider: ReusableViewProvider) -> NSAttributedString {
+    func render(
+        theme: MarkdownTheme,
+        context: MarkdownContent,
+        viewProvider: ReusableViewProvider,
+        decoration: TextBuilder.InlineTextDecoration? = nil
+    ) -> NSAttributedString {
         assert(Thread.isMainThread)
         switch self {
         case let .text(string):
-            return context.cachedBodyText(string, theme: theme)
+            // Past the cache, never into it: a decoration may carry an
+            // attachment, and an attachment holds a view, which belongs to the
+            // one text view it was built for rather than to every view that
+            // draws the same words.
+            let rendered = context.cachedBodyText(string, theme: theme)
+            return decoration?(rendered) ?? rendered
         case .softBreak:
             return context.cachedBodyText(" ", theme: theme)
         case .lineBreak:
@@ -47,7 +67,9 @@ extension MarkdownInlineNode {
             return text
         case let .emphasis(children):
             let ans = NSMutableAttributedString()
-            children.map { $0.render(theme: theme, context: context, viewProvider: viewProvider) }.forEach { ans.append($0) }
+            children
+                .map { $0.render(theme: theme, context: context, viewProvider: viewProvider, decoration: decoration) }
+                .forEach { ans.append($0) }
             ans.addAttributes(
                 [
                     .underlineStyle: NSUnderlineStyle.thick.rawValue,
@@ -58,7 +80,9 @@ extension MarkdownInlineNode {
             return ans
         case let .strong(children):
             let ans = NSMutableAttributedString()
-            children.map { $0.render(theme: theme, context: context, viewProvider: viewProvider) }.forEach { ans.append($0) }
+            children
+                .map { $0.render(theme: theme, context: context, viewProvider: viewProvider, decoration: decoration) }
+                .forEach { ans.append($0) }
             ans.enumerateAttribute(.font, in: NSRange(location: 0, length: ans.length)) { value, range, _ in
                 #if canImport(UIKit)
                     guard let font = value as? UIFont, font != theme.fonts.body else {
@@ -80,7 +104,9 @@ extension MarkdownInlineNode {
             return ans
         case let .strikethrough(children):
             let ans = NSMutableAttributedString()
-            children.map { $0.render(theme: theme, context: context, viewProvider: viewProvider) }.forEach { ans.append($0) }
+            children
+                .map { $0.render(theme: theme, context: context, viewProvider: viewProvider, decoration: decoration) }
+                .forEach { ans.append($0) }
             ans.addAttributes(
                 [.strikethroughStyle: NSUnderlineStyle.thick.rawValue],
                 range: NSRange(location: 0, length: ans.length)
@@ -88,7 +114,9 @@ extension MarkdownInlineNode {
             return ans
         case let .link(destination, children):
             let ans = NSMutableAttributedString()
-            children.map { $0.render(theme: theme, context: context, viewProvider: viewProvider) }.forEach { ans.append($0) }
+            children
+                .map { $0.render(theme: theme, context: context, viewProvider: viewProvider, decoration: decoration) }
+                .forEach { ans.append($0) }
             ans.addAttributes(
                 [
                     .link: destination,

--- a/Tests/MarkdownViewTests/MarkdownViewInlineDecorationTests.swift
+++ b/Tests/MarkdownViewTests/MarkdownViewInlineDecorationTests.swift
@@ -1,0 +1,84 @@
+// Deliberately not `@testable`: half of what is under test here is that a
+// client module — one that only ever sees the public surface — can subclass
+// ``MarkdownTextView`` and override the decoration hook at all.
+import MarkdownView
+import Testing
+
+#if canImport(UIKit)
+    import UIKit
+#elseif canImport(AppKit)
+    import AppKit
+#endif
+
+/// A subclass written the way a client writes one: it marks a name it knows
+/// about, and it knows about it only after `rosterLoaded` says so.
+@MainActor
+private final class ChipTextView: MarkdownTextView {
+    static let marker = NSAttributedString.Key("inlineDecorationTestMarker")
+
+    var rosterLoaded = true
+
+    override func decorate(inlineText text: NSAttributedString, theme _: MarkdownTheme) -> NSAttributedString {
+        guard rosterLoaded else { return text }
+        let range = (text.string as NSString).range(of: "@agent")
+        guard range.location != NSNotFound else { return text }
+        let decorated = NSMutableAttributedString(attributedString: text)
+        decorated.addAttribute(Self.marker, value: true, range: range)
+        return decorated
+    }
+}
+
+@MainActor
+private func markedRangeCount(in view: MarkdownTextView) -> Int {
+    let text = view.textLabelView.attributedText
+    var count = 0
+    text.enumerateAttribute(
+        ChipTextView.marker,
+        in: NSRange(location: 0, length: text.length)
+    ) { value, _, _ in
+        if value != nil { count += 1 }
+    }
+    return count
+}
+
+struct MarkdownViewInlineDecorationTests {
+    @MainActor
+    @Test("A subclass decorates body text, and only body text")
+    func decoratesBodyText() {
+        let view = ChipTextView()
+        view.frame = .init(x: 0, y: 0, width: 400, height: 200)
+
+        // Three candidates, one decoration: the code span and the link
+        // destination are their own inline nodes and never reach the hook.
+        view.setMarkdown("hello @agent, not `@agent`, not [x](https://e.com/@agent)")
+
+        #expect(markedRangeCount(in: view) == 1)
+    }
+
+    @MainActor
+    @Test("The default view leaves text alone")
+    func defaultViewDecoratesNothing() {
+        let view = MarkdownTextView()
+        view.frame = .init(x: 0, y: 0, width: 400, height: 200)
+        view.setMarkdown("hello @agent")
+
+        #expect(markedRangeCount(in: view) == 0)
+    }
+
+    @MainActor
+    @Test("Invalidating rebuilds text the fragment cache would have reused")
+    func invalidationRebuildsDecoratedText() {
+        let view = ChipTextView()
+        view.frame = .init(x: 0, y: 0, width: 400, height: 200)
+        view.rosterLoaded = false
+        view.setMarkdown("hello @agent")
+        #expect(markedRangeCount(in: view) == 0)
+
+        // The document has not changed, so nothing but the invalidation can
+        // make the cached fragment give way.
+        view.rosterLoaded = true
+        view.invalidateInlineDecoration()
+
+        #expect(markedRangeCount(in: view) == 1)
+    }
+}


### PR DESCRIPTION
Showing an `@mention` as a chip means turning a stretch of plain words into an attachment, and there was no way in. Inline rendering lives in an extension on `MarkdownInlineNode`, and a method on an extension of an enum is dispatched statically — so no amount of subclassing reaches it. The seam has to be declared where a subclass can see it and then handed down.

`MarkdownTextView` is no longer `final`, and carries one overridable hook: `decorate(inlineText:theme:)`, offered every run of body text on its way into the document. The builder takes it as a closure, threads it through the block and list processors, and calls it in the `.text` case of the inline renderer. Code spans, math, HTML and an image's source are each their own inline node and never pass through, so a pattern written inside backticks is not mistaken for prose. Nothing internal became public in the process.

The call sits *after* `cachedBodyText` rather than inside it: a decoration may carry an attachment, an attachment holds a view, and a view belongs to the one text view it was built for rather than to every view that draws the same words. The shared inline cache is left as it was.

Two per-view caches would otherwise hold decorated text against state that has moved on — the block fragment cache, and a table's record of what it last rendered — so `invalidateInlineDecoration()` clears both and rebuilds. A table needs `forgetRenderedSource()` for this: its rows and its theme are unchanged, and what they render *to* is not.

## Verification

- `swift build`, `swift test` — 126 tests, no failures
- `xcodebuild` on `Example.xcworkspace` scheme `Example`, Mac Catalyst — Build Succeeded
- `Script/test.sh` — exit 0 on all six destinations (macOS, Mac Catalyst, iOS, iOS Simulator, xrOS, xrOS Simulator)

New test `MarkdownViewInlineDecorationTests` deliberately uses a plain `import MarkdownView` rather than `@testable`, since `@testable` treats a public class as open and would prove nothing about external subclassability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)