### PR TITLE
Set the theme and the content in one build

### DIFF
--- a/Sources/MarkdownView/MarkdownTextView/MarkdownTextView.swift
+++ b/Sources/MarkdownView/MarkdownTextView/MarkdownTextView.swift
@@ -23,10 +23,12 @@ import MarkdownParser
 
         @available(*, deprecated, renamed: "textLabelView")
         public var textView: TextLabelView { textLabelView }
-        public var theme: MarkdownTheme = .default {
-            didSet {
-                guard oldValue != theme else { return }
-                textLabelView.selectionBackgroundColor = theme.colors.selectionBackground
+        var themeStorage: MarkdownTheme = .default
+        public var theme: MarkdownTheme {
+            get { themeStorage }
+            set {
+                guard themeStorage != newValue else { return }
+                applyWithoutRebuilding(theme: newValue)
                 use(content)
             }
         }
@@ -134,6 +136,27 @@ import MarkdownParser
             setupCombine()
         }
 
+        /// Replaces the displayed content and the theme in one build.
+        ///
+        /// Assigning ``theme`` alone rebuilds the document the view already
+        /// holds — right when the theme is all that changed, wasted when new
+        /// content lands in the same breath. A view fed themed content from
+        /// the outside (a sizing pass serving differently-inked bubbles, a
+        /// row being reconfigured) should use this instead of setting the
+        /// two properties in sequence.
+        open func setContentImmediately(_ content: MarkdownContent, theme: MarkdownTheme) {
+            applyWithoutRebuilding(theme: theme)
+            setContentImmediately(content)
+        }
+
+        /// Stores the theme and restyles the label without rebuilding the
+        /// current document — for callers about to replace it anyway.
+        func applyWithoutRebuilding(theme: MarkdownTheme) {
+            guard themeStorage != theme else { return }
+            themeStorage = theme
+            textLabelView.selectionBackgroundColor = theme.colors.selectionBackground
+        }
+
         /// Replaces the displayed content, coalesced by ``throttleInterval``.
         /// Safe to call at high frequency (e.g. while streaming).
         open func setContent(_ content: MarkdownContent) {
@@ -186,10 +209,12 @@ import MarkdownParser
 
         @available(*, deprecated, renamed: "textLabelView")
         public var textView: TextLabelView { textLabelView }
-        public var theme: MarkdownTheme = .default {
-            didSet {
-                guard oldValue != theme else { return }
-                textLabelView.selectionBackgroundColor = theme.colors.selectionBackground
+        var themeStorage: MarkdownTheme = .default
+        public var theme: MarkdownTheme {
+            get { themeStorage }
+            set {
+                guard themeStorage != newValue else { return }
+                applyWithoutRebuilding(theme: newValue)
                 use(content)
             }
         }
@@ -305,6 +330,27 @@ import MarkdownParser
             contentSubject.send(content)
             use(content)
             setupCombine()
+        }
+
+        /// Replaces the displayed content and the theme in one build.
+        ///
+        /// Assigning ``theme`` alone rebuilds the document the view already
+        /// holds — right when the theme is all that changed, wasted when new
+        /// content lands in the same breath. A view fed themed content from
+        /// the outside (a sizing pass serving differently-inked bubbles, a
+        /// row being reconfigured) should use this instead of setting the
+        /// two properties in sequence.
+        open func setContentImmediately(_ content: MarkdownContent, theme: MarkdownTheme) {
+            applyWithoutRebuilding(theme: theme)
+            setContentImmediately(content)
+        }
+
+        /// Stores the theme and restyles the label without rebuilding the
+        /// current document — for callers about to replace it anyway.
+        func applyWithoutRebuilding(theme: MarkdownTheme) {
+            guard themeStorage != theme else { return }
+            themeStorage = theme
+            textLabelView.selectionBackgroundColor = theme.colors.selectionBackground
         }
 
         /// Replaces the displayed content, coalesced by ``throttleInterval``.

--- a/Sources/MarkdownView/MarkdownView+SwiftUI/MarkdownView+Coordinator.swift
+++ b/Sources/MarkdownView/MarkdownView+SwiftUI/MarkdownView+Coordinator.swift
@@ -99,8 +99,7 @@ final class MarkdownViewCoordinator {
         lastText = text
         lastParseResult = result
         lastContent = nil
-        view.theme = theme
-        view.setContentImmediately(content)
+        view.setContentImmediately(content, theme: theme)
         // A deferred (throttled) apply happens outside a SwiftUI update
         // cycle; invalidating the intrinsic size is what prompts SwiftUI to
         // re-query sizeThatFits(_:) for the new content.

--- a/Sources/MarkdownView/MarkdownView+SwiftUI/MarkdownView+RepresentableBase.swift
+++ b/Sources/MarkdownView/MarkdownView+SwiftUI/MarkdownView+RepresentableBase.swift
@@ -42,8 +42,7 @@ extension MarkdownViewRepresentableBase {
                 coordinator.lastText = ""
                 coordinator.lastParseResult = nil
                 coordinator.lastContent = markdownContent
-                view.theme = theme
-                view.setContentImmediately(markdownContent)
+                view.setContentImmediately(markdownContent, theme: theme)
                 view.invalidateIntrinsicContentSize()
                 coordinator.lastTheme = theme
             }


### PR DESCRIPTION
Assigning `theme` rebuilds the document the view already holds — wasted work when the caller replaces the content in the same breath. Both SwiftUI apply paths did that sequence, so an appearance flip rebuilt every hosted view twice; so does any external feeder serving differently-themed documents through one view (AirBuild's transcript sizing twin, measuring user- and bot-inked bubbles in turn).

`setContentImmediately(_:theme:)` stores the theme, restyles the label, and builds once with the new content. The plain `theme` setter keeps its meaning for a view whose content stays.

Verified: Example builds for Mac Catalyst, `swift test` green on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)